### PR TITLE
[update] codebuild - fix get latest build

### DIFF
--- a/services/codebuild.sh
+++ b/services/codebuild.sh
@@ -7,7 +7,7 @@ aws_codebuild_list() {
 aws_codebuild_get_latest_build() {
 	aws_codebuild_project_name=$1
 	echo Get the latest build of project ${aws_codebuild_project_name:?"aws_codebuild_project_name is unset or empty"}
-	aws codebuild batch-get-builds --ids $(aws codebuild list-builds-for-project --project-name $aws_codebuild_project_name --query "*[] | [1]" --output text)
+	aws codebuild batch-get-builds --ids $(aws codebuild list-builds-for-project --project-name $aws_codebuild_project_name --query "*[] | [0]" | tr -d \''"\')
 }
 
 aws_codebuild_get_latest_build_with_hint() {


### PR DESCRIPTION
When codebuild build list has so many elements that AWS have to paginate, using `--output text` will list unexpected elements (elements that come from many pages)
```
❯ aws codebuild list-builds-for-project --project-name xxx --query "*[] | [0]" --output text

xxx:xxxxx-xxxxx-xxxxx-xxxxx-xxxxx7e4
xxx:xxxxx-xxxxx-xxxxx-xxxxx-xxxxx7b1
xxx:xxxxx-xxxxx-xxxxx-xxxxx-xxxxx9d6
```

So I fix a little bit
```
❯ aws codebuild list-builds-for-project --project-name xxx --query "*[] | [0]" | tr -d \''"\'

xxx:xxxxx-xxxxx-xxxxx-xxxxx-xxxxx7e4
```